### PR TITLE
fix(catalog): caddy image name and group/user creation

### DIFF
--- a/tv-shows-catalog/caddy/Dockerfile
+++ b/tv-shows-catalog/caddy/Dockerfile
@@ -2,7 +2,7 @@ FROM caddy:2.7-alpine
 
 RUN apk add --no-cache nss-tools && \
     mkdir -p /etc/caddy /srv /data/caddy /config/caddy && \
-    adduser --disabled-password --gecos "" --no-create-home caddy && \
+    addgroup -S caddy && adduser -D -S --no-create-home -G caddy caddy && \
     chown -R caddy:caddy /etc/caddy /srv /data /config
 
 COPY ./Caddyfile /etc/caddy/Caddyfile

--- a/tv-shows-catalog/docker-compose.prod.yaml
+++ b/tv-shows-catalog/docker-compose.prod.yaml
@@ -22,7 +22,7 @@ services:
       - API_BASE_URL=${API_BASE_URL}
 
   caddy:
-    image: caddy:2.7-alpine
+    image: caddy-server
     build:
       context: ./caddy
       dockerfile: Dockerfile


### PR DESCRIPTION
This PR fix image name in docker-compose because the previous name was creating issue when rebuilding.

Also, `addgroup` was missing in Dockerfile.