### PR TITLE
ci: set paths execution rule

### DIFF
--- a/.github/workflows/build-blog.yml
+++ b/.github/workflows/build-blog.yml
@@ -2,6 +2,8 @@ name: Build blog
 
 on:
   pull_request:
+    paths:
+      - 'blog/**'
 
 permissions:
     contents: read

--- a/.github/workflows/build-catalog.yml
+++ b/.github/workflows/build-catalog.yml
@@ -2,6 +2,8 @@ name: Build catalog
 
 on: 
   pull_request:
+    paths:
+      - 'tv-shows-catalog/**'
 
 permissions:
     contents: read

--- a/.github/workflows/build-restau.yml
+++ b/.github/workflows/build-restau.yml
@@ -2,6 +2,8 @@ name: Build restaurant
 
 on:
   pull_request:
+    paths:
+      - 'restaurant-website/**'
 
 permissions:
   contents: read


### PR DESCRIPTION
This PR adds the "paths" option to all build test workflows to reduce the use of actions.

See : https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore