### PR TITLE
perf(catalog): improve perms handling

### DIFF
--- a/tv-shows-catalog/client/Dockerfile
+++ b/tv-shows-catalog/client/Dockerfile
@@ -1,5 +1,6 @@
 # Base client
-FROM node:lts-alpine3.19 as base
+FROM node:20-alpine3.19 as base
+USER node
 WORKDIR /app
 
 COPY --chown=node:node package*.json .
@@ -13,10 +14,8 @@ HEALTHCHECK --interval=5s --timeout=1s \
 # Development
 FROM base as dev
 ENV NODE_ENV=development
-RUN npm install && \
-    chown -R node:node /app
+RUN npm install
 COPY --chown=node:node . .
-USER node
 CMD ["npm", "run", "dev"]
 
 # Build
@@ -24,19 +23,15 @@ FROM base as build
 RUN npm ci && \
     npm cache clean --force
 COPY --chown=node:node . .
-RUN npm run build && \
-    chown -R node:node /app
+RUN npm run build
 
 # Pre-production
 FROM build as pre-prod
 ENV NODE_ENV=production
-USER node
 CMD ["npm", "run", "preview"]
 
 # Production
 FROM base as prod
 ENV NODE_ENV=production
 COPY --from=build /app/build /app/build
-COPY --from=build /app/node_modules /app/node_modules
-USER node
 CMD ["node", "build/index.js"]

--- a/tv-shows-catalog/server/Dockerfile
+++ b/tv-shows-catalog/server/Dockerfile
@@ -1,5 +1,6 @@
 # Base server
-FROM node:lts-alpine3.19 as base
+FROM node:20-alpine3.19 as base
+USER node
 WORKDIR /app
 
 COPY --chown=node:node package*.json .
@@ -13,10 +14,8 @@ HEALTHCHECK --interval=5s --timeout=1s \
 # Development
 FROM base as dev
 ENV NODE_ENV=development
-RUN npm install && \
-    chown -R node:node /app
+RUN npm install
 COPY --chown=node:node . .
-USER node
 CMD [ "npm", "run", "start:dev" ]
 
 # Build
@@ -24,13 +23,11 @@ FROM base as build
 RUN npm ci && \
     npm cache clean --force
 COPY --chown=node:node . .
-RUN npm run build && \
-    chown -R node:node /app
+RUN npm run build
 
 # Pre-production
 FROM build as pre-prod
 ENV NODE_ENV=production
-USER node
 CMD ["npm", "run", "start:prod"]
 
 # Production
@@ -38,5 +35,4 @@ FROM base as prod
 ENV NODE_ENV=production
 COPY --from=build /app/dist /app/dist
 COPY --from=build /app/node_modules /app/node_modules
-USER node
 CMD ["node", "dist/main.js"]


### PR DESCRIPTION
Removed useless chown command is order to speed up build. 
Also removed the copy of node_modules/ for client in production.