### PR TITLE
build: prevent issue with libc6 in node alpine images

### DIFF
--- a/tv-shows-catalog/client/Dockerfile
+++ b/tv-shows-catalog/client/Dockerfile
@@ -1,5 +1,8 @@
 # Base client
 FROM node:21-alpine3.19 as base
+
+RUN apk add --no-cache libc6-compat
+
 USER node
 WORKDIR /app
 
@@ -33,5 +36,5 @@ CMD ["npm", "run", "preview"]
 # Production
 FROM base as prod
 ENV NODE_ENV=production
-COPY --from=build /app/build /app/build
+COPY --from=build --chown=node:node /app/build /app/build
 CMD ["node", "build/index.js"]

--- a/tv-shows-catalog/server/Dockerfile
+++ b/tv-shows-catalog/server/Dockerfile
@@ -1,5 +1,8 @@
 # Base server
 FROM node:21-alpine3.19 as base
+
+RUN apk add --no-cache libc6-compat
+
 USER node
 WORKDIR /app
 
@@ -33,6 +36,6 @@ CMD ["npm", "run", "start:prod"]
 # Production
 FROM base as prod
 ENV NODE_ENV=production
-COPY --from=build /app/dist /app/dist
-COPY --from=build /app/node_modules /app/node_modules
+COPY --from=build --chown=node:node /app/dist /app/dist
+COPY --from=build --chown=node:node /app/node_modules /app/node_modules
 CMD ["node", "dist/main.js"]


### PR DESCRIPTION
This package is not necessary for these particular apps, but it's a good practice to install it to avoid any problems if we need to add new packages.

-> https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine